### PR TITLE
Allow getting things by name

### DIFF
--- a/semabadge.hs
+++ b/semabadge.hs
@@ -2,7 +2,8 @@
 
 module Main
   ( main
-  ) where
+  )
+where
 
 import qualified Control.Monad.IO.Class as MonadIO
 import qualified Data.Aeson as Aeson
@@ -75,13 +76,13 @@ notFoundHandler = do
 
 semaphore :: Aeson.FromJSON json => Token -> String -> IO json
 semaphore token path = do
-  let url =
-        concat
-          [ "https://semaphoreci.com/api/v1"
-          , path
-          , "?auth_token="
-          , unwrapToken token
-          ]
+  let
+    url = concat
+      [ "https://semaphoreci.com/api/v1"
+      , path
+      , "?auth_token="
+      , unwrapToken token
+      ]
   request <- Client.parseRequest url
   manager <- Tls.getGlobalManager
   response <- Client.httpLbs request manager
@@ -90,19 +91,17 @@ semaphore token path = do
     Right json -> pure json
 
 badgeFor :: Name -> Status -> LazyByteString.ByteString
-badgeFor name status =
-  Barrier.renderBadge
-    (Lens.set Barrier.right (colorFor status) Barrier.flat)
-    (unwrapName name)
-    (unwrapStatus status)
+badgeFor name status = Barrier.renderBadge
+  (Lens.set Barrier.right (colorFor status) Barrier.flat)
+  (unwrapName name)
+  (unwrapStatus status)
 
 colorFor :: Status -> Barrier.Color
-colorFor status =
-  case unwrapStatus status of
-    "failed" -> Barrier.red
-    "passed" -> Barrier.brightgreen
-    "pending" -> Barrier.yellow
-    _ -> Barrier.orange
+colorFor status = case unwrapStatus status of
+  "failed" -> Barrier.red
+  "passed" -> Barrier.brightgreen
+  "pending" -> Barrier.yellow
+  _ -> Barrier.orange
 
 data Config = Config
   { configPort :: Warp.Port

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.0
+resolver: lts-12.0


### PR DESCRIPTION
Fixes #3. 

This adds the following endpoints:

- `/users/:user/projects/:project/branches/:branch`
- `/users/:user/projects/:project/servers/:server`

They work exactly like their counterparts except that they look up the project by name. For example:

- `/users/tfausak/projects/semabadge/branches/master`
- `/users/tfausak/projects/semabadge/servers/production`

Note that the user name comes from GitHub, not Semaphore. 